### PR TITLE
Bugfix/gatewayicon

### DIFF
--- a/src/Mondu/Mondu/Gateway.php
+++ b/src/Mondu/Mondu/Gateway.php
@@ -33,7 +33,7 @@ class Gateway extends WC_Payment_Gateway {
     $this->method_title = __('Mondu Rechnungskauf', 'mondu');
     $this->method_description = __('Rechnungskauf - jetzt kaufen, später bezahlen', 'mondu');
     $this->has_fields = true;
-    $this->icon = apply_filters('woocommerce_gateway_icon', MONDU_PUBLIC_PATH . '/views/mondu.svg');
+    $this->icon = apply_filters('woocommerce_gateway_icon', MONDU_PUBLIC_PATH . '/views/mondu.svg', $this->id);
 
     $this->init_form_fields();
     $this->init_settings();

--- a/src/Mondu/Mondu/GatewayDirectDebit.php
+++ b/src/Mondu/Mondu/GatewayDirectDebit.php
@@ -29,7 +29,7 @@ class GatewayDirectDebit extends WC_Payment_Gateway {
     $this->method_title = __('Mondu SEPA-Lastschrift', 'mondu');
     $this->method_description = __('SEPA-Lastschrift - jetzt kaufen, später bezahlen', 'mondu');
     $this->has_fields = true;
-    $this->icon = apply_filters('woocommerce_gateway_icon', MONDU_PUBLIC_PATH . '/views/mondu.svg');
+    $this->icon = apply_filters('woocommerce_gateway_icon', MONDU_PUBLIC_PATH . '/views/mondu.svg', $this->id);
 
     $this->init_form_fields();
     $this->init_settings();

--- a/src/Mondu/Mondu/GatewayInstallment.php
+++ b/src/Mondu/Mondu/GatewayInstallment.php
@@ -29,7 +29,7 @@ class GatewayInstallment extends WC_Payment_Gateway {
     $this->method_title = __('Mondu Ratenzahlung', 'mondu');
     $this->method_description = __('Ratenzahlung - Bequem in Raten per Bankeinzug zahlen', 'mondu');
     $this->has_fields = true;
-    $this->icon = apply_filters( 'woocommerce_gateway_icon',  MONDU_PUBLIC_PATH . '/views/mondu.svg');
+    $this->icon = apply_filters( 'woocommerce_gateway_icon',  MONDU_PUBLIC_PATH . '/views/mondu.svg', $this->id);
     $this->init_form_fields();
     $this->init_settings();
 


### PR DESCRIPTION
The filter woocommerce_gateway_icon requires the gateway id as the last argument or active filters will crash the page

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>