### PR TITLE
Checkout: fix action for succesful payment

### DIFF
--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -102,7 +102,7 @@ class Plugin {
       $webhooks->register_routes();
     });
 
-    add_action('woocommerce_checkout_order_processed', function($order_id) {
+    add_action('woocommerce_payment_successful_result', function($order_id) {
       $mondu_order_id = WC()->session->get('mondu_order_id');
 
       WC()->session->set('woocommerce_order_id', $order_id);


### PR DESCRIPTION
The action woocommerce_checkout_order_processed is not the correct indicator if payment was succesful but only if all data are correct.

You can stop the mondu payment process in the popup go back one and retry it and now there is no payment popup but the order is flagged as paid while mondu status is cancelled.

woocommerce_payment_successful_result is the correct action.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>