### PR TITLE
Use order number as external reference id

### DIFF
--- a/src/Mondu/Mondu/MonduRequestWrapper.php
+++ b/src/Mondu/Mondu/MonduRequestWrapper.php
@@ -67,7 +67,7 @@ class MonduRequestWrapper {
     }
 
     $mondu_order_id = get_post_meta($order_id, Plugin::ORDER_ID_KEY, true);
-    $params = ['external_reference_id' => (string) $order_id];
+    $params = ['external_reference_id' => $order->get_order_number()];
     $response = $this->wrap_with_mondu_log_event('update_external_info', array($mondu_order_id, $params));
     return $response['order'];
   }

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -127,7 +127,7 @@ class OrderData {
   public static function order_data_from_wc_order(WC_Order $order) {
     $order_data = [
       'currency' => get_woocommerce_currency(),
-      'external_reference_id' => (string) $order->get_id(),
+      'external_reference_id' => $order->get_order_number(),
       'lines' => [],
       'amount' => [],
     ];
@@ -181,7 +181,7 @@ class OrderData {
    */
   public static function invoice_data_from_wc_order(WC_Order $order) {
     $invoice_data = [
-      'external_reference_id' => (string) $order->get_id(),
+      'external_reference_id' => $order->get_order_number(),
       'invoice_url' => Helper::create_invoice_url($order->get_id()),
       'gross_amount_cents' => round((float) $order->get_total() * 100),
       'tax_cents' => round((float) ($order->get_total_tax() - $order->get_shipping_tax()) * 100), # Considering that is not possible to save taxes that does not belongs to products, removes shipping taxes here


### PR DESCRIPTION
One of the merchants also use the [Sequential Order Numbers plugin](https://de.wordpress.org/plugins/wt-woocommerce-sequential-order-numbers) (See the notes) and according to their's website, it is recommended to use `get_order_number` method instead of `get_id`.