### PR TITLE
Validate checkout hotfix

### DIFF
--- a/src/Mondu/Mondu/Controllers/OrdersController.php
+++ b/src/Mondu/Mondu/Controllers/OrdersController.php
@@ -49,9 +49,16 @@ class OrdersController extends WP_REST_Controller {
     $errors = new WP_Error();
 
     $posted_data = WC()->checkout()->get_posted_data();
-    call_user_func_array(array(WC()->checkout(), 'update_session'), array($posted_data));
-    call_user_func_array(array(WC()->checkout(), 'validate_checkout'), array($posted_data, $errors));
-    do_action('woocommerce_after_checkout_validation', $posted_data, $errors);
+
+    $validate_checkout_method = new \ReflectionMethod(get_class(WC()->checkout()), 'validate_checkout');
+    $update_session_method = new \ReflectionMethod(get_class(WC()->checkout()), 'update_session');
+
+    $update_session_method->setAccessible(true);
+    $validate_checkout_method->setAccessible(true);
+
+    $update_session_method->invoke(WC()->checkout(), $posted_data);
+    $validate_checkout_method->invoke(WC()->checkout(), $posted_data, $errors);
+    // do_action('woocommerce_after_checkout_validation', $posted_data, $errors);
 
     foreach ($errors->errors as $code => $messages) {
       $data = $errors->get_error_data($code);

--- a/views/checkout/payment-form.php
+++ b/views/checkout/payment-form.php
@@ -85,18 +85,31 @@
     }
   }
 
-  function handleErrors(errors = null) {
-    jQuery('.woocommerce-error').remove();
-    if (errors) {
-      jQuery('form.woocommerce-checkout').prepend(errors);
-    } else {
+  function handleErrors(error_message = null) {
+    var scrollElement = jQuery('.woocommerce-NoticeGroup-updateOrderReview, .woocommerce-NoticeGroup-checkout');
+    if (!scrollElement.length ) {
+      scrollElement = jQuery('form.checkout');
+    }
+
+    if(!error_message) {
       jQuery('form.woocommerce-checkout').prepend(
         '<div class="woocommerce-error">' +
         '<?php echo __('Error processing checkout. Please try again.', 'mondu'); ?>' +
         '</div>'
       );
+      jQuery.scroll_to_notices( scrollElement );
+      return;
     }
-    jQuery.scroll_to_notices(jQuery('.woocommerce-error'));
+    // from woocommerce checkout.js submit_error function line 570
+    var $checkout_form = jQuery('form.checkout');
+    jQuery('.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message').remove();
+    $checkout_form.prepend('<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + error_message + '</div>');
+    $checkout_form.removeClass('processing').unblock();
+    $checkout_form.find('.input-text, select, input:checkbox').trigger('validate').trigger('blur');
+    var scrollElement = jQuery('.woocommerce-NoticeGroup-updateOrderReview, .woocommerce-NoticeGroup-checkout');
+
+    jQuery.scroll_to_notices( scrollElement );
+    jQuery( document.body ).trigger( 'checkout_error' , [ error_message ] );
   }
 
   jQuery(document).ready(function () {
@@ -108,6 +121,7 @@
         payWithMondu();
         return false;
       }
+      return false;
     });
   });
 </script>


### PR DESCRIPTION
Apparently call_user_func_array is unable to call protected methods which is treated as a warning hence no error is thrown during the checkout. This pr replaces call_user_func_array with ReflectionMethod. Also Includes changes in payment-form.php

![image](https://user-images.githubusercontent.com/62335544/211851537-abc000bf-ff18-485f-90fb-d087083e6320.png)
