### PR TITLE
Checkout: fix order not created after authorization

### DIFF
--- a/views/checkout/payment-form.php
+++ b/views/checkout/payment-form.php
@@ -60,7 +60,6 @@
       onClose: () => {
         monduUnblock();
         checkoutCallback();
-        result = '';
         return new Promise((resolve) => resolve())
       },
       onSuccess: () => {
@@ -80,6 +79,7 @@
     if (result === 'success') {
       jQuery('#place_order').parents('form').submit();
     } else {
+      result = '';
       jQuery(document.body).trigger('wc_update_cart');
       jQuery(document.body).trigger('update_checkout');
       window.monduCheckout.destroy();


### PR DESCRIPTION
On our checkout the js checkoutCallback is fired than onClose and afterwards checkout_place_order
which leads to the result variable being cleared by the onClose function.
The Mondu Widget is shown again and the order is not created.
Only clear the result variable when not successful on close.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>