### PR TITLE
WCPDF Invoice: Language change and formatting

### DIFF
--- a/src/Mondu/Mondu/Presenters/PaymentInfo.php
+++ b/src/Mondu/Mondu/Presenters/PaymentInfo.php
@@ -70,6 +70,7 @@ class PaymentInfo {
         </section>
         <hr>
         <?php printf($this->get_mondu_payment_html()) ?>
+        <?php printf($this->get_mondu_net_terms()) ?>
         <?php printf($this->get_mondu_invoices_html()) ?>
       <?php
     } else {
@@ -91,7 +92,7 @@ class PaymentInfo {
    * @return string
    * @throws Exception
    */
-  public function get_mondu_payment_html() {
+  public function get_mondu_payment_html($pdf=false) {
     if (!in_array($this->order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
       return null;
     }
@@ -102,26 +103,45 @@ class PaymentInfo {
 
     $bank_account = $this->order_data['bank_account'];
 
+    if ($pdf) {
+      if (function_exists('wcpdf_get_document')) {
+        $document = wcpdf_get_document( 'invoice', $this->order, false );
+        $invoice_number = $document->get_number()->get_formatted();
+      } else {
+        $invoice_number = $this->order->get_order_number();
+      }
+
+      $invoice_number = apply_filters('mondu_invoice_reference_id', $invoice_number);
+    }
+
     ob_start();
 
     ?>
       <section class="woocommerce-order-details mondu-payment">
-        <p>
-          <span><strong><?php _e('Account holder', 'mondu'); ?>:</strong></span>
-          <span><?php printf($bank_account['account_holder']); ?></span>
-        </p>
-        <p>
-          <span><strong><?php _e('Bank', 'mondu'); ?>:</strong></span>
-          <span><?php printf($bank_account['bank']); ?></span>
-        </p>
-        <p>
-          <span><strong><?php _e('IBAN', 'mondu'); ?>:</strong></span>
-          <span><?php printf($bank_account['iban']); ?></span>
-        </p>
-        <p>
-          <span><strong><?php _e('BIC', 'mondu'); ?>:</strong></span>
-          <span><?php printf($bank_account['bic']); ?></span>
-        </p>
+        <table>
+          <tr>
+            <td><strong><?php _e('Account holder', 'mondu'); ?>:</strong></td>
+            <td><?php printf($bank_account['account_holder']); ?></span></td>
+          </tr>
+          <tr>
+            <td><strong><?php _e('Bank', 'mondu'); ?>:</strong></td>
+            <td><?php printf($bank_account['bank']); ?></td>
+          </tr>
+          <tr>
+            <td><strong><?php _e('IBAN', 'mondu'); ?>:</strong></td>
+            <td><?php printf($bank_account['iban']); ?></td>
+          </tr>
+          <tr>
+            <td><strong><?php _e('BIC', 'mondu'); ?>:</strong></td>
+            <td><?php printf($bank_account['bic']); ?></td>
+          </tr>
+          <?php if ($pdf) { ?>
+          <tr>
+            <td><strong><?php _e('Purpose', 'mondu'); ?>:</strong></td>
+            <td><?php printf($invoice_number); ?></td>
+          </tr>
+          <?php } ?>
+        </table>
       </section>
     <?php
 
@@ -196,7 +216,7 @@ class PaymentInfo {
    * @return string
    * @throws Exception
    */
-  public function get_mondu_wcpdf_section_html() {
+  public function get_mondu_wcpdf_section_html($pdf=false) {
     if (!in_array($this->order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
       return null;
     }
@@ -207,12 +227,12 @@ class PaymentInfo {
       $order_data = $this->order_data;
       ?>
         <p>
-          <strong>
+          <strong style="color: red;">
             <?php _e('Please transfer your invoice exclusively to the following bank account', 'mondu'); ?>:
           </strong>
         </p>
         <br>
-        <?php printf($this->get_mondu_payment_html()) ?>
+        <?php printf($this->get_mondu_payment_html($pdf)) ?>
         <?php printf($this->get_mondu_net_terms()) ?>
       <?php
     } else {

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -185,8 +185,18 @@ class OrderData {
    */
   public static function invoice_data_from_wc_order(WC_Order $order) {
     $except_keys = self::add_lines_to_except_keys([], 'invoice');
+
+    if (function_exists('wcpdf_get_document')) {
+      $document = wcpdf_get_document( 'invoice', $order, false );
+      $invoice_number = $document->get_number()->get_formatted();
+    } else {
+      $invoice_number = $order->get_order_number();
+    }
+
+    $invoice_number = apply_filters('mondu_invoice_reference_id', $invoice_number);
+
     $invoice_data = [
-      'external_reference_id' => $order->get_order_number(),
+      'external_reference_id' => $invoice_number,
       'invoice_url' => Helper::create_invoice_url($order->get_id()),
       'gross_amount_cents' => round((float) $order->get_total() * 100),
       'tax_cents' => round((float) ($order->get_total_tax() - $order->get_shipping_tax()) * 100), # Considering that is not possible to save taxes that does not belongs to products, removes shipping taxes here

--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -139,6 +139,7 @@ class Plugin {
     add_action('wpo_wcpdf_after_order_data', [$this, 'wcpdf_add_status_to_invoice_when_invoice_is_cancelled'], 10, 2);
     add_action('wpo_wcpdf_meta_box_after_document_data', [$this, 'wcpdf_add_paid_to_invoice_admin_when_invoice_is_paid'], 10, 2);
     add_action('wpo_wcpdf_meta_box_after_document_data', [$this, 'wcpdf_add_status_to_invoice_admin_when_invoice_is_cancelled'], 10, 2);
+    add_action('wpo_wcpdf_reload_text_domains', [$this, 'wcpdf_add_mondu_payment_language_switch'], 10, 1);
   }
 
   public function load_textdomain() {
@@ -256,7 +257,7 @@ class Plugin {
     if ($template_type !== 'invoice') return;
 
     $payment_info = new PaymentInfo($order->get_id());
-    echo $payment_info->get_mondu_wcpdf_section_html();
+    echo $payment_info->get_mondu_wcpdf_section_html(true);
   }
 
   /**
@@ -371,6 +372,14 @@ class Plugin {
         </div>
       <?php
     }
+  }
+
+  /**
+   * @param $locale
+   */
+  public function wcpdf_add_mondu_payment_language_switch($locale) {
+    unload_textdomain( 'mondu' );
+    $this->load_textdomain();
   }
 
   /**


### PR DESCRIPTION
Add WCPDF Pro language switch action and fix some formatting.
The invoice PDF does not have much space so use a table.
Make the title red so the customer can see it and add the invoice purpose.

Also show the net terms in the order backend.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>