### PR TITLE
bugfix: Non mondu orders crash with an error message

### DIFF
--- a/src/Mondu/Mondu/Presenters/PaymentInfo.php
+++ b/src/Mondu/Mondu/Presenters/PaymentInfo.php
@@ -20,8 +20,17 @@ class PaymentInfo {
   public function __construct($order_id) {
     $this->order = new WC_Order($order_id);
     $this->mondu_request_wrapper = new MonduRequestWrapper();
-    $this->order_data = $this->get_order();
-    $this->invoices_data = $this->get_invoices();
+    $order_data = $this->get_order();
+    if (!$order_data)
+      $order_data = array();
+
+    $this->order_data = $order_data;
+
+    $invoices_data = $this->get_invoices();
+    if (!$invoices_data)
+      $invoices_data = array();
+
+    $this->invoices_data = $invoices_data;
   }
 
   public function get_order_data() {


### PR DESCRIPTION
NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: Cannot assign null to property Mondu\Mondu\Presenters\PaymentInfo::$order_data of type array in /var/www/wordpress/wp-content/plugins/Woocommerce-Mondu/src/Mondu/Mondu/Presenters/PaymentInfo.php:23

This is probably not the best fix as discussed with Jakub.

The entire class should not run when Mondu is not the payment method.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>