### PR TITLE
Support Order Pay page

### DIFF
--- a/src/Mondu/Mondu/Controllers/OrdersController.php
+++ b/src/Mondu/Mondu/Controllers/OrdersController.php
@@ -34,14 +34,28 @@ class OrdersController extends WP_REST_Controller {
 
   public function create(WP_REST_Request $request) {
     try {
-      $this->validate_checkout();
-      if (wc_notice_count('error') === 0) {
-        $order = $this->mondu_request_wrapper->create_order();
+      $data = $request->get_params();
+      // We need to distinguish order pay page and checkout page
+      if (array_key_exists('orderpay', $data) && $data['orderpay'] == 'yes') {
+        // We only need to check the terms and condition box
+        if (empty( $data['terms'] ) && ! empty( $data['terms-field'] ) ) {
+          wc_add_notice( __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ), 'error' );
+          throw new MonduException(__('Error processing checkout. Please try again.', 'mondu'));
+        }
+        $order = $this->mondu_request_wrapper->create_order_pay_page($data);
         return array(
           'token' => $order['uuid']
         );
       } else {
-        throw new MonduException(__('Error processing checkout. Please try again.', 'mondu'));
+        $this->validate_checkout();
+        if (wc_notice_count('error') === 0) {
+          $order = $this->mondu_request_wrapper->create_order();
+          return array(
+            'token' => $order['uuid']
+          );
+        } else {
+          throw new MonduException(__('Error processing checkout. Please try again.', 'mondu'));
+        }
       }
     } catch (ResponseException | MonduException $e) {
       return array(

--- a/src/Mondu/Mondu/Gateway.php
+++ b/src/Mondu/Mondu/Gateway.php
@@ -75,6 +75,11 @@ class Gateway extends WC_Payment_Gateway {
    */
   public function payment_fields() {
     parent::payment_fields();
+    $order_id = 0;
+
+    if ( is_wc_endpoint_url( 'order-pay' ) ) {
+      $order_id = absint( get_query_var( 'order-pay' ) );
+    }
 
     include MONDU_VIEW_PATH . '/checkout/payment-form.php';
   }

--- a/src/Mondu/Mondu/GatewayDirectDebit.php
+++ b/src/Mondu/Mondu/GatewayDirectDebit.php
@@ -75,6 +75,11 @@ class GatewayDirectDebit extends WC_Payment_Gateway {
    */
   public function payment_fields() {
     parent::payment_fields();
+    $order_id = 0;
+
+    if ( is_wc_endpoint_url( 'order-pay' ) ) {
+      $order_id = absint( get_query_var( 'order-pay' ) );
+    }
 
     include MONDU_VIEW_PATH . '/checkout/payment-form.php';
   }

--- a/src/Mondu/Mondu/GatewayInstallment.php
+++ b/src/Mondu/Mondu/GatewayInstallment.php
@@ -75,6 +75,11 @@ class GatewayInstallment extends WC_Payment_Gateway {
    */
   public function payment_fields() {
     parent::payment_fields();
+    $order_id = 0;
+
+    if ( is_wc_endpoint_url( 'order-pay' ) ) {
+      $order_id = absint( get_query_var( 'order-pay' ) );
+    }
 
     include MONDU_VIEW_PATH . '/checkout/payment-form.php';
   }

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -127,6 +127,74 @@ class OrderData {
    *
    * @return array[]
    */
+  public static function raw_order_data_from_wc_order(WC_Order $order, $payment_method = 'invoice') {
+    $order_data_extra = OrderData::order_data_from_wc_order($order);
+
+    $customer_id              = $order->get_customer_id();
+
+    $billing_email            = $order->get_billing_email();
+    $billing_first_name       = $order->get_billing_first_name();
+    $billing_last_name        = $order->get_billing_last_name();
+    $billing_company_name     = $order->get_billing_company();
+    $billing_phone            = $order->get_billing_phone();
+
+    $billing_address_line1    = $order->get_billing_address_1();
+    $billing_address_line2    = $order->get_billing_address_2();
+    $billing_city             = $order->get_billing_city();
+    $billing_state            = $order->get_billing_state();
+    $billing_zip_code         = $order->get_billing_postcode();
+    $billing_country_code     = $order->get_billing_country();
+
+    $shipping_address_line1    = $order->get_shipping_address_1();
+    $shipping_address_line2    = $order->get_shipping_address_2();
+    $shipping_city             = $order->get_shipping_city();
+    $shipping_state            = $order->get_shipping_state();
+    $shipping_zip_code         = $order->get_shipping_postcode();
+    $shipping_country_code     = $order->get_shipping_country();
+
+    $order_data = [
+      'payment_method' => $payment_method,
+      'currency' => get_woocommerce_currency(),
+      'external_reference_id' => (string) $order->get_order_number(), // We will update this id when woocommerce order is created
+      'gross_amount_cents' => $order_data_extra['amount']['gross_amount_cents'],
+      'language' => substr(get_locale(), 0, 2),
+      'buyer' => [
+        'first_name' => isset($billing_first_name) && Helper::not_null_or_empty($billing_first_name) ? $billing_first_name : null,
+        'last_name' => isset($billing_last_name) && Helper::not_null_or_empty($billing_last_name) ? $billing_last_name : null,
+        'company_name' => isset($billing_company_name) && Helper::not_null_or_empty($billing_company_name) ? $billing_company_name : null,
+        'email' => isset($billing_email) && Helper::not_null_or_empty($billing_email) ? $billing_email : null,
+        'phone' => isset($billing_phone) && Helper::not_null_or_empty($billing_phone) ? $billing_phone : null,
+        'external_reference_id' => isset($customer_id) && Helper::not_null_or_empty($customer_id) ? (string) $customer_id : null,
+        'is_registered' => is_user_logged_in(),
+      ],
+      'billing_address' => [
+        'address_line1' => isset($billing_address_line1) && Helper::not_null_or_empty($billing_address_line1) ? $billing_address_line1 : null,
+        'address_line2' => isset($billing_address_line2) && Helper::not_null_or_empty($billing_address_line2) ? $billing_address_line2 : null,
+        'city' => isset($billing_city) && Helper::not_null_or_empty($billing_city) ? $billing_city : null,
+        'state' => isset($billing_state) && Helper::not_null_or_empty($billing_state) ? $billing_state : null,
+        'zip_code' => isset($billing_zip_code) && Helper::not_null_or_empty($billing_zip_code) ? $billing_zip_code : null,
+        'country_code' => isset($billing_country_code) && Helper::not_null_or_empty($billing_country_code) ? $billing_country_code : null,
+      ],
+      'shipping_address' => [
+        'address_line1' => isset($shipping_address_line1) && Helper::not_null_or_empty($shipping_address_line1) ? $shipping_address_line1 : null,
+        'address_line2' => isset($shipping_address_line2) && Helper::not_null_or_empty($shipping_address_line2) ? $shipping_address_line2 : null,
+        'city' => isset($shipping_city) && Helper::not_null_or_empty($shipping_city) ? $shipping_city : null,
+        'state' => isset($shipping_state) && Helper::not_null_or_empty($shipping_state) ? $shipping_state : null,
+        'zip_code' => isset($shipping_zip_code) && Helper::not_null_or_empty($shipping_zip_code) ? $shipping_zip_code : null,
+        'country_code' => isset($shipping_country_code) && Helper::not_null_or_empty($shipping_country_code) ? $shipping_country_code : null,
+      ],
+      'lines' => $order_data_extra['lines'],
+      'amount' => $order_data_extra['amount'],
+    ];
+
+    return $order_data;
+  }
+
+  /**
+   * @param $order
+   *
+   * @return array[]
+   */
   public static function order_data_from_wc_order(WC_Order $order) {
     $order_data = [
       'currency' => get_woocommerce_currency(),

--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -255,6 +255,10 @@ class Plugin {
   public function wcpdf_add_mondu_payment_info_to_pdf($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
+
     $payment_info = new PaymentInfo($order->get_id());
     echo $payment_info->get_mondu_wcpdf_section_html();
   }
@@ -267,6 +271,10 @@ class Plugin {
    */
   public function wcpdf_add_status_to_invoice_when_order_is_cancelled($template_type, $order) {
     if ($template_type !== 'invoice') return;
+
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
 
     $payment_info = new PaymentInfo($order->get_id());
     $order_data = $payment_info->get_order_data();
@@ -290,10 +298,14 @@ class Plugin {
   public function wcpdf_add_paid_to_invoice_when_invoice_is_paid($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    $payment_info = new PaymentInfo($order->get_id());
-    $invoice_data = $payment_info->get_invoices_data()[0];
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
 
-    if ($invoice_data['paid_out']) {
+    $payment_info = new PaymentInfo($order->get_id());
+    $invoice_data = $payment_info->get_invoices_data();
+
+    if ($invoice_data && $invoice_data[0]['paid_out']) {
       ?>
         <tr class="invoice-status">
           <th><?php _e('Mondu Invoice paid','mondu'); ?>:</th>
@@ -312,10 +324,14 @@ class Plugin {
   public function wcpdf_add_status_to_invoice_when_invoice_is_cancelled($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    $payment_info = new PaymentInfo($order->get_id());
-    $invoice_data = $payment_info->get_invoices_data()[0];
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
 
-    if ($invoice_data['state'] === 'canceled') {
+    $payment_info = new PaymentInfo($order->get_id());
+    $invoice_data = $payment_info->get_invoices_data();
+
+    if ($invoice_data && $invoice_data[0]['state'] === 'canceled') {
       ?>
         <tr class="invoice-status">
           <th><?php _e('Mondu Invoice state','mondu'); ?>:</th>
@@ -333,6 +349,10 @@ class Plugin {
    */
   public function wcpdf_add_paid_to_invoice_admin_when_invoice_is_paid($document, $order) {
     if ($document->get_type() !== 'invoice') return;
+
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
 
     $payment_info = new PaymentInfo($order->get_id());
     $invoice_data = $payment_info->get_invoices_data()[0];
@@ -357,6 +377,10 @@ class Plugin {
    */
   public function wcpdf_add_status_to_invoice_admin_when_invoice_is_cancelled($document, $order) {
     if ($document->get_type() !== 'invoice') return;
+
+    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return;
+    }
 
     $payment_info = new PaymentInfo($order->get_id());
     $invoice_data = $payment_info->get_invoices_data()[0];


### PR DESCRIPTION
The order pay page is used when an order is created in the backend of Woocommerce and the user pays the precreated order. It is a simplified checkout page as all data are already fixed and added to the order.
The information are obtained by the url and order id.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>