### PR TITLE
Mondu only block order if we have an actually payment

### DIFF
--- a/src/Mondu/Mondu/MonduRequestWrapper.php
+++ b/src/Mondu/Mondu/MonduRequestWrapper.php
@@ -66,7 +66,7 @@ class MonduRequestWrapper {
    */
   public function get_order($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -83,7 +83,7 @@ class MonduRequestWrapper {
    */
   public function update_external_info($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -102,7 +102,7 @@ class MonduRequestWrapper {
    */
   public function adjust_order($order_id, $data_to_update) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -119,7 +119,7 @@ class MonduRequestWrapper {
    */
   public function cancel_order($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -136,7 +136,7 @@ class MonduRequestWrapper {
    */
   public function ship_order($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -156,7 +156,7 @@ class MonduRequestWrapper {
    */
   public function get_invoices($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -173,7 +173,7 @@ class MonduRequestWrapper {
    */
   public function get_invoice($order_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -254,7 +254,7 @@ class MonduRequestWrapper {
    * @throws ResponseException
    */
   public function update_order_if_changed_some_fields($order) {
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -278,7 +278,7 @@ class MonduRequestWrapper {
    */
   public function order_status_changed($order_id, $from_status, $to_status) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 
@@ -301,7 +301,7 @@ class MonduRequestWrapper {
    */
   public function order_refunded($order_id, $refund_id) {
     $order = new WC_Order($order_id);
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!PLUGIN::order_has_mondu($order)) {
       return;
     }
 

--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -149,8 +149,22 @@ class Plugin {
     load_plugin_textdomain('mondu', false, $plugin_rel_path);
   }
 
-  public function change_address_warning(WC_Order $order) {
+  public static function order_has_mondu(WC_Order $order) {
     if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+      return false;
+    }
+
+    // Check if we actually have a payment as well
+    $mondu_order_id = get_post_meta($order->get_id(), Plugin::ORDER_ID_KEY, true);
+    if ( !$mondu_order_id ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public function change_address_warning(WC_Order $order) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
@@ -258,7 +272,7 @@ class Plugin {
   public function wcpdf_add_mondu_payment_info_to_pdf($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
@@ -275,7 +289,7 @@ class Plugin {
   public function wcpdf_add_status_to_invoice_when_order_is_cancelled($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
@@ -301,7 +315,7 @@ class Plugin {
   public function wcpdf_add_paid_to_invoice_when_invoice_is_paid($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
@@ -327,7 +341,7 @@ class Plugin {
   public function wcpdf_add_status_to_invoice_when_invoice_is_cancelled($template_type, $order) {
     if ($template_type !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
@@ -353,14 +367,14 @@ class Plugin {
   public function wcpdf_add_paid_to_invoice_admin_when_invoice_is_paid($document, $order) {
     if ($document->get_type() !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
     $payment_info = new PaymentInfo($order->get_id());
-    $invoice_data = $payment_info->get_invoices_data()[0];
+    $invoice_data = $payment_info->get_invoices_data();
 
-    if ($invoice_data['paid_out']) {
+    if ($invoice_data && $invoice_data[0]['paid_out']) {
       ?>
         <div class="invoice-number">
           <p>
@@ -381,14 +395,14 @@ class Plugin {
   public function wcpdf_add_status_to_invoice_admin_when_invoice_is_cancelled($document, $order) {
     if ($document->get_type() !== 'invoice') return;
 
-    if (!in_array($order->get_payment_method(), Plugin::PAYMENT_METHODS)) {
+    if (!$this->order_has_mondu($order)) {
       return;
     }
 
     $payment_info = new PaymentInfo($order->get_id());
-    $invoice_data = $payment_info->get_invoices_data()[0];
+    $invoice_data = $payment_info->get_invoices_data();
 
-    if ($invoice_data['state'] === 'canceled') {
+    if ($invoice_data && $invoice_data[0]['state'] === 'canceled') {
       ?>
         <div class="invoice-number">
           <p>

--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -168,6 +168,11 @@ class Plugin {
       return;
     }
 
+    $payment_info = new PaymentInfo($order->get_id());
+    $order_data = $payment_info->get_order_data();
+    if ($order_data && $order_data['state'] == 'declined')
+      return;
+
     wc_enqueue_js("
       jQuery(document).ready(function() {
         jQuery('a.edit_address').remove();


### PR DESCRIPTION
When creating a backend offer/order for a customer and we preselect Mondu as the payment method, the entire order is blocked for editing.
Make sure that there is actually a payment uuid connected to the order before blocking it out.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech,de>