### PR TITLE
Order Backend: Add Button to resend order data

### DIFF
--- a/src/Mondu/Mondu/Presenters/PaymentInfo.php
+++ b/src/Mondu/Mondu/Presenters/PaymentInfo.php
@@ -73,6 +73,9 @@ class PaymentInfo {
                 <button data-mondu='<?php echo(json_encode($mondu_data)) ?>' id="mondu-create-invoice-button" type="submit" class="button grant_access">
                   <?php _e('Create Invoice', 'mondu'); ?>
                 </button>
+                <button data-mondu='<?php echo(json_encode($mondu_data)) ?>' id="mondu-resend-data-button" type="submit" class="button grant_access">
+                  <?php _e('Resend Order Data', 'mondu'); ?>
+                </button>
               <?php
             }
           ?>

--- a/views/admin/js/invoice.php
+++ b/views/admin/js/invoice.php
@@ -46,6 +46,30 @@
           }
         });
       }
+    });
+
+    $('#mondu-resend-data-button').on('click', function (e) {
+      e.preventDefault();
+
+      if(confirm("Are you sure you want to resend the order data to Mondu?")) {
+        var attributes = JSON.parse($('#mondu-create-invoice-button')[0].attributes['data-mondu'].value);
+
+        jQuery.ajax({
+          type: 'POST',
+          url: ajaxurl,
+          data: {
+            action: 'resend_order_data',
+            ...attributes
+          },
+          success: function(res) {
+            if(res.error) {
+              alert(res.message);
+            } else {
+              location.reload();
+            }
+          }
+        });
+      }
     })
   });
 </script>


### PR DESCRIPTION
If there is a problem submitting changed order data to the API we have no way of retriggering the process.
Add a button the admin can press.

Signed-Off-By: Sven Auhagen <sven.auhagen@voleatech.de>