### PR TITLE
Order language 

### DIFF
--- a/src/Mondu/Mondu/Controllers/OrdersController.php
+++ b/src/Mondu/Mondu/Controllers/OrdersController.php
@@ -49,7 +49,8 @@ class OrdersController extends WP_REST_Controller {
       } else {
         $this->validate_checkout();
         if (wc_notice_count('error') === 0) {
-          $order = $this->mondu_request_wrapper->create_order();
+          $lang = $data['lang'] ?? null;
+          $order = $this->mondu_request_wrapper->create_order($lang);
           return array(
             'token' => $order['uuid']
           );

--- a/src/Mondu/Mondu/MonduRequestWrapper.php
+++ b/src/Mondu/Mondu/MonduRequestWrapper.php
@@ -23,14 +23,14 @@ class MonduRequestWrapper {
    * @throws MonduException
    * @throws ResponseException
    */
-  public function create_order() {
+  public function create_order($lang = null) {
     $payment_method = WC()->session->get('chosen_payment_method');
     if (!in_array($payment_method, Plugin::PAYMENT_METHODS)) {
       return;
     }
     $payment_method = array_search($payment_method, Plugin::PAYMENT_METHODS);
 
-    $order_data = OrderData::create_order_data($payment_method);
+    $order_data = OrderData::create_order_data($payment_method, $lang);
     $response = $this->wrap_with_mondu_log_event('create_order', array($order_data));
     $order = $response['order'];
     WC()->session->set('mondu_order_id', $order['uuid']);

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -10,9 +10,13 @@ class OrderData {
   /**
    * @return array[]
    */
-  public static function create_order_data($payment_method) {
+  public static function create_order_data($payment_method, $lang = null) {
     $except_keys = self::add_lines_to_except_keys(['amount'], 'order');
     $order_data = self::raw_order_data($payment_method);
+    
+    if ($lang) {
+      $order_data['language'] = substr($lang, 0, 2);
+    }
 
     return Helper::remove_keys($order_data, $except_keys);
   }
@@ -43,13 +47,11 @@ class OrderData {
     $cart_totals = WC()->session->get('cart_totals');
     $customer = WC()->session->get('customer');
     $cart_hash = WC()->cart->get_cart_hash();
-
     $order_data = [
       'payment_method' => $payment_method,
       'currency' => get_woocommerce_currency(),
       'external_reference_id' => $cart_hash, // We will update this id when woocommerce order is created
       'gross_amount_cents' => round((float) $cart_totals['total'] * 100),
-      'language' => substr(get_locale(), 0, 2),
       'buyer' => [
         'first_name' => isset($customer['first_name']) && Helper::not_null_or_empty($customer['first_name']) ? $customer['first_name'] : null,
         'last_name' => isset($customer['last_name']) && Helper::not_null_or_empty($customer['last_name']) ? $customer['last_name'] : null,
@@ -158,7 +160,6 @@ class OrderData {
       'currency' => get_woocommerce_currency(),
       'external_reference_id' => (string) $order->get_order_number(), // We will update this id when woocommerce order is created
       'gross_amount_cents' => $order_data_extra['amount']['gross_amount_cents'],
-      'language' => substr(get_locale(), 0, 2),
       'buyer' => [
         'first_name' => isset($billing_first_name) && Helper::not_null_or_empty($billing_first_name) ? $billing_first_name : null,
         'last_name' => isset($billing_last_name) && Helper::not_null_or_empty($billing_last_name) ? $billing_last_name : null,

--- a/src/Mondu/Plugin.php
+++ b/src/Mondu/Plugin.php
@@ -77,6 +77,8 @@ class Plugin {
      */
     add_action('init', [$this, 'load_textdomain']);
 
+    add_filter('mondu_order_locale', [$this, 'get_mondu_order_locale'], 1);
+
     /*
      * Adds the mondu gateway to the list of gateways
      * (And remove it again if we're not in Germany)
@@ -447,5 +449,9 @@ class Plugin {
   private function get_wc_customer() {
     $customer = isset(WC()->customer) ? WC()->customer : new WC_Customer(get_current_user_id());
     return $customer;
+  }
+
+  public function get_mondu_order_locale() {
+    return apply_filters( 'wpml_current_language', null );
   }
 }

--- a/views/checkout/payment-form.php
+++ b/views/checkout/payment-form.php
@@ -40,13 +40,14 @@
       return;
     }
     monduBlock();
-
     if (orderpay === true) {
       orderId = <?php echo $order_id; ?>;
       data = checkoutForm().serialize() + "&orderpay=true" + "&order_id=" + orderId;
     } else {
       data = checkoutForm().serialize();
     }
+    var lang = '<?php echo apply_filters( 'mondu_order_locale', get_locale() ); ?>'
+    data += '&lang=' + lang;
 
     jQuery.ajax({
       type: 'POST',


### PR DESCRIPTION
## Description

Added mondu_order_locale filter. It reads the user locale from wpml plugin or returns null otherwise.
if the merchant uses other localization plugin they need to add new handler to the filter like so
`    add_filter('mondu_order_locale', [$this, 'func_to_get_locale'], 2);
` 

## Release information

Release: -
Tickets: CON-786
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
