### PR TITLE
Fix webhooks signature

### DIFF
--- a/src/Mondu/Mondu/Models/SignatureVerifier.php
+++ b/src/Mondu/Mondu/Models/SignatureVerifier.php
@@ -37,7 +37,7 @@ class SignatureVerifier {
    * @return bool
    */
   public function create_hmac($payload) {
-    return hash_hmac('sha256', json_encode($payload), $this->secret);
+    return hash_hmac('sha256', json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT), $this->secret);
   }
 
   /**

--- a/src/Mondu/Mondu/MonduRequestWrapper.php
+++ b/src/Mondu/Mondu/MonduRequestWrapper.php
@@ -343,7 +343,7 @@ class MonduRequestWrapper {
   public function register_webhook(string $topic) {
     $response = $this->wrap_with_mondu_log_event('register_webhook', array($topic));
 
-    return $response['webhooks'];
+    return @$response['webhooks'];
   }
 
   /**


### PR DESCRIPTION
## Description

Considering that the Mondu API returns the webhook params as `topic: order/declined` (for example), the `json_encode` was encoding the params wrongly, causing signature mismatched errors. I also added cases when the object is empty and with a different Unicode.

## Release information

Release:
Tickets: CON-1001

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works
