### PR TITLE
Fix wrong setting name

### DIFF
--- a/src/Mondu/Mondu/Support/Helper.php
+++ b/src/Mondu/Mondu/Support/Helper.php
@@ -143,15 +143,13 @@ class Helper {
 	public static function is_production() {
 		$global_settings = get_option( Plugin::OPTION_NAME );
 
-		$is_production = false;
 		if ( is_array( $global_settings )
-			&& isset( $global_settings['field_sandbox_or_production'] )
-			&& 'production' === $global_settings['field_sandbox_or_production']
+			&& isset( $global_settings['sandbox_or_production'] )
+			&& 'production' === $global_settings['sandbox_or_production']
 		) {
-			$is_production = true;
+			return true;
 		}
-
-		return $is_production;
+		return false;
 	}
 
 	public static function log( array $message, $level = 'DEBUG' ) {


### PR DESCRIPTION
## Description

The wrong setting name was making the API always call the demo endpoint.

Fixes # (issue)

## Release information

Release: p
Tickets: PT-8

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works
