### PR TITLE
Ensure that ampersand is escaped in the webhooks signature verifier

### DIFF
--- a/src/Mondu/Mondu/Models/SignatureVerifier.php
+++ b/src/Mondu/Mondu/Models/SignatureVerifier.php
@@ -20,7 +20,7 @@ class SignatureVerifier {
 	}
 
 	public function create_hmac( $payload ) {
-		return hash_hmac('sha256', wp_json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT), $this->secret);
+		return hash_hmac('sha256', wp_json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT | JSON_HEX_AMP), $this->secret);
 	}
 
 


### PR DESCRIPTION
## Description

Ensure that ampersand is escaped in the webhooks signature verifier

Fixes [PT-263](https://mondu.atlassian.net/browse/PT-263)

## Release information

Release: p
Tickets: PT-263

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works


[PT-263]: https://mondu.atlassian.net/browse/PT-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ