### PR TITLE
Support more plugins modifying order number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM wordpress:6.3.1
-ENV WOOCOMMERCE_VERSION 8.0.3
-ENV WOOCOMMERCE_PDF_INVOICES_VERSION 3.6.3
+FROM wordpress:6.4.1
+ENV WOOCOMMERCE_VERSION 8.3.1
+ENV WOOCOMMERCE_PDF_INVOICES_VERSION 3.7.2
+ENV SEQUENCIAL_ORDER_NUMBERS_VERSION 1.5.6
 
 RUN apt update
 RUN apt -y install wget
@@ -34,7 +35,7 @@ RUN wget https://downloads.wordpress.org/plugin/woocommerce-pdf-invoices-packing
 
 RUN rm -rf /usr/src/wordpress/wp-content/plugins/wt-woocommerce-sequential-order-numbers
 
-RUN wget https://downloads.wordpress.org/plugin/wt-woocommerce-sequential-order-numbers.1.5.2.zip -O /tmp/wt-woocommerce-sequential-order-numbers.zip \
+RUN wget https://downloads.wordpress.org/plugin/wt-woocommerce-sequential-order-numbers.${SEQUENCIAL_ORDER_NUMBERS_VERSION}.zip -O /tmp/wt-woocommerce-sequential-order-numbers.zip \
   && cd /usr/src/wordpress/wp-content/plugins \
   && unzip /tmp/wt-woocommerce-sequential-order-numbers.zip \
   && rm /tmp/wt-woocommerce-sequential-order-numbers.zip

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: mondu-ai, arthurmmoreira, tikohov20
 Tags: mondu, woocommerce, e-commerce, ecommerce, store, sales, sell, woo, woo commerce, shop, cart, shopping cart, sell online, checkout, payment, payments, bnpl, b2b
 Requires at least: 5.9.0
 Tested up to: 6.2.2
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -56,6 +56,10 @@ Check out [Frequently Asked Questions](https://www.mondu.ai/faq) in the Mondu we
 3. Grow now. Pay better.
 
 == Changelog ==
+
+= 2.1.2 =
+
+* Support more plugins modifying order number
 
 = 2.1.1 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 2.1.2 =
+
+* Support more plugins modifying order number
+
 = 2.1.1 =
 
 * Fix cancel and decline hosted checkout params

--- a/languages/mondu-de_AT.po
+++ b/languages/mondu-de_AT.po
@@ -85,7 +85,7 @@ msgstr "Mondu Bestellinformationen"
 
 #: src/Mondu/Admin/Order.php:64
 #: src/Mondu/Admin/Order.php:92
-#: src/Mondu/Admin/Settings.php:133
+#: src/Mondu/Admin/Settings.php:132
 msgid "Bad Request."
 msgstr "Schlechte Anfrage."
 

--- a/languages/mondu-de_DE.po
+++ b/languages/mondu-de_DE.po
@@ -85,7 +85,7 @@ msgstr "Mondu Bestellinformationen"
 
 #: src/Mondu/Admin/Order.php:64
 #: src/Mondu/Admin/Order.php:92
-#: src/Mondu/Admin/Settings.php:133
+#: src/Mondu/Admin/Settings.php:132
 msgid "Bad Request."
 msgstr "Schlechte Anfrage."
 

--- a/languages/mondu-fr_FR.po
+++ b/languages/mondu-fr_FR.po
@@ -85,7 +85,7 @@ msgstr "Informations Commande Mondu"
 
 #: src/Mondu/Admin/Order.php:64
 #: src/Mondu/Admin/Order.php:92
-#: src/Mondu/Admin/Settings.php:133
+#: src/Mondu/Admin/Settings.php:132
 msgid "Bad Request."
 msgstr "Mauvaise requête."
 

--- a/languages/mondu-nl_NL.po
+++ b/languages/mondu-nl_NL.po
@@ -85,7 +85,7 @@ msgstr "Mondu Order Informatie"
 
 #: src/Mondu/Admin/Order.php:64
 #: src/Mondu/Admin/Order.php:92
-#: src/Mondu/Admin/Settings.php:133
+#: src/Mondu/Admin/Settings.php:132
 msgid "Bad Request."
 msgstr "Slecht verzoek."
 

--- a/languages/mondu.pot
+++ b/languages/mondu.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3.
 msgid ""
 msgstr ""
-"Project-Id-Version: Mondu Buy Now Pay Later 2.1.1\n"
+"Project-Id-Version: Mondu Buy Now Pay Later 2.1.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/mondu-buy-now-pay-later\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-10-12T08:58:46+00:00\n"
+"POT-Creation-Date: 2023-11-02T10:25:48+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: mondu\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: src/Mondu/Admin/Order.php:64
 #: src/Mondu/Admin/Order.php:92
-#: src/Mondu/Admin/Settings.php:133
+#: src/Mondu/Admin/Settings.php:132
 msgid "Bad Request."
 msgstr ""
 

--- a/mondu-buy-now-pay-later.php
+++ b/mondu-buy-now-pay-later.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mondu Buy Now Pay Later
  * Plugin URI: https://github.com/mondu-ai/bnpl-checkout-woocommerce/releases
  * Description: Mondu provides B2B E-commerce and B2B marketplaces with an online payment solution to buy now and pay later.
- * Version: 2.1.1
+ * Version: 2.1.2
  * Author: Mondu
  * Author URI: https://mondu.ai
  *
@@ -25,7 +25,7 @@ if ( !defined( 'ABSPATH' ) ) {
 	die( 'Direct access not allowed' );
 }
 
-define( 'MONDU_PLUGIN_VERSION', '2.1.1' );
+define( 'MONDU_PLUGIN_VERSION', '2.1.2' );
 define( 'MONDU_PLUGIN_FILE', __FILE__ );
 define( 'MONDU_PLUGIN_PATH', __DIR__ );
 define( 'MONDU_PLUGIN_BASENAME', plugin_basename(MONDU_PLUGIN_FILE) );

--- a/releaser.sh
+++ b/releaser.sh
@@ -27,7 +27,7 @@ echo "Removing old zip file"
 rm -f "mondu-buy-now-pay-later-$version.zip"
 mkdir -p mondu-buy-now-pay-later
 echo "Generating zip file"
-rsync -r --exclude "*.DS_Store" --exclude "exporter.sh" --exclude "Dockerfile" --exclude "docker-compose.yml" --exclude ".gitignore" --exclude ".git" --exclude ".github" --exclude "composer.json" --exclude "composer.lock" --exclude "vendor" --exclude "pbs-rules-set.xml" --exclude "mondu-buy-now-pay-later" . mondu-buy-now-pay-later
+rsync -r --exclude "*.DS_Store" --exclude "releaser.sh" --exclude "Dockerfile" --exclude "docker-compose.yml" --exclude ".gitignore" --exclude ".git" --exclude ".github" --exclude "composer.json" --exclude "composer.lock" --exclude "vendor" --exclude "pbs-rules-set.xml" --exclude "mondu-buy-now-pay-later" . mondu-buy-now-pay-later
 zip -r -D "mondu-buy-now-pay-later-$version.zip" mondu-buy-now-pay-later/*
 rm -r mondu-buy-now-pay-later
 echo "Done"

--- a/src/Mondu/Mondu/Support/Helper.php
+++ b/src/Mondu/Mondu/Support/Helper.php
@@ -4,6 +4,7 @@ namespace Mondu\Mondu\Support;
 
 use Mondu\Plugin;
 use WC_Order;
+use WP_Query;
 
 class Helper {
 	/**
@@ -146,36 +147,82 @@ class Helper {
 			$search_no_suffix_and_prefix = preg_replace( "/{$suffix}\z/i", '', $search_no_suffix );
 			$final_search                = empty( $search_no_suffix_and_prefix ) ? $order_number : $search_no_suffix_and_prefix;
 
+			$search_term_fallback = substr( $final_search, strlen( $prefix ) );
+			$search_term_fallback = ltrim( $search_term_fallback, 0 );
+
+			if ( strlen( $suffix ) > 0 ) {
+				$search_term_fallback = substr( $search_term_fallback, 0, -strlen( $suffix ) );
+			}
+
 			if ( 'yes' == $wcj_order_numbers_enabled ) {
 				if ( 'no' == get_option( 'wcj_order_number_sequential_enabled' ) ) {
 					$order_id = $final_search;
 				} else {
-					$search_key = '_wcj_order_number';
+					$search_key  = '_wcj_order_number';
 					$search_term = $final_search;
 				}
 			}
 		}
 
 		if ( !isset( $order_id ) ) {
-			$orders = get_posts(
-				array(
-					'numberposts' => 1,
-					'meta_key'    => $search_key,
-					'meta_value'  => $search_term,
-					'post_type'   => 'shop_order',
-					'post_status' => 'any',
-					'fields'      => 'ids',
+			$args  = array(
+				'numberposts'            => 1,
+				'post_type'              => 'shop_order',
+				'fields'                 => 'ids',
+				'post_status'            => 'any',
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'meta_query'             => array(
+					array(
+						'key'     => $search_key,
+						'value'   => $search_term,
+						'compare' => '=',
+					),
 				)
 			);
-			if ( !empty( $orders ) ) {
-				list( $order_id ) = $orders;
+			$query = new WP_Query( $args );
+
+			if ( !empty( $query->posts ) ) {
+				$order_id = $query->posts[ 0 ];
+			} elseif ( isset( $search_term_fallback ) ) {
+				$args  = array(
+					'numberposts'            => 1,
+					'post_type'              => 'shop_order',
+					'fields'                 => 'ids',
+					'post_status'            => 'any',
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					'meta_query'             => array(
+						array(
+							'key'     => $search_key,
+							'value'   => $search_term_fallback,
+							'compare' => '=',
+						),
+					)
+				);
+				$query = new WP_Query( $args );
+
+				if ( !empty( $query->posts ) ) {
+					$order_id = $query->posts[ 0 ];
+				}
 			}
 		}
-		if ( $order_id ) {
+
+		if ( isset( $order_id ) ) {
 			$order = wc_get_order( $order_id );
+
 			if ( $order ) {
 				return $order;
 			}
+		} else {
+			Helper::log([
+				'message'              => 'Error trying to fetch the order',
+				'order_id_isset'       => isset( $order_id ),
+				'order_number'         => $order_number,
+				'search_key'           => $search_key,
+				'search_term'          => $search_term,
+				'search_term_fallback' => isset( $search_term_fallback ),
+			]);
 		}
 	}
 

--- a/src/Mondu/Mondu/Support/Helper.php
+++ b/src/Mondu/Mondu/Support/Helper.php
@@ -116,39 +116,65 @@ class Helper {
 			return $order;
 		}
 
-		$orders = wc_get_orders([
-			'return'     => 'ids',
-			'limit'      => 1,
-			'meta_query' => [
-				[
-					'key'        => '_order_number',
-					'value'      => $order_number,
-					'comparison' => '=',
-				],
-			],
-		]);
+		$search_key = '_order_number';
+		$search_term = $order_number;
 
-		$order_id = $orders ? current($orders) : null;
-
-		$order = wc_get_order( $order_id );
-		if ( $order ) {
-			return $order;
+		if ( is_plugin_active( 'custom-order-numbers-for-woocommerce/custom-order-numbers-for-woocommerce.php' ) ) {
+			$search_key = '_alg_wc_full_custom_order_number';
 		}
 
-		$orders = get_posts( [
-			'numberposts' => 1,
-			'meta_key'    => '_order_number',
-			'meta_value'  => $order_number,
-			'post_type'   => 'shop_order',
-			'post_status' => 'any',
-			'fields'      => 'ids',
-		] );
+		if ( is_plugin_active( 'wp-lister-amazon/wp-lister-amazon.php' ) ) {
+			$search_key = '_wpla_amazon_order_id';
+		}
 
-		$order_id = $orders ? current($orders) : null;
+		if ( is_plugin_active( 'yith-woocommerce-sequential-order-number-premium/init.php' ) ) {
+			$search_key = '_ywson_custom_number_order_complete';
+		}
 
-		$order = wc_get_order( $order_id );
-		if ( $order ) {
-			return $order;
+		if ( is_plugin_active( 'woocommerce-jetpack/woocommerce-jetpack.php' ) || is_plugin_active( 'booster-plus-for-woocommerce/booster-plus-for-woocommerce.php' ) ) {
+			$wcj_order_numbers_enabled = get_option( 'wcj_order_numbers_enabled' );
+
+			// Get prefix and suffix options
+			$prefix = do_shortcode( get_option( 'wcj_order_number_prefix', '' ) );
+			$prefix .= date_i18n( get_option( 'wcj_order_number_date_prefix', '' ) );
+			$suffix = do_shortcode( get_option( 'wcj_order_number_suffix', '' ) );
+			$suffix .= date_i18n( get_option( 'wcj_order_number_date_suffix', '' ) );
+
+			// Ignore suffix and prefix from search input
+			$search_no_suffix            = preg_replace( "/\A{$prefix}/i", '', $order_number );
+			$search_no_suffix_and_prefix = preg_replace( "/{$suffix}\z/i", '', $search_no_suffix );
+			$final_search                = empty( $search_no_suffix_and_prefix ) ? $order_number : $search_no_suffix_and_prefix;
+
+			if ( 'yes' == $wcj_order_numbers_enabled ) {
+				if ( 'no' == get_option( 'wcj_order_number_sequential_enabled' ) ) {
+					$order_id = $final_search;
+				} else {
+					$search_key = '_wcj_order_number';
+					$search_term = $final_search;
+				}
+			}
+		}
+
+		if ( !isset( $order_id ) ) {
+			$orders = get_posts(
+				array(
+					'numberposts' => 1,
+					'meta_key'    => $search_key,
+					'meta_value'  => $search_term,
+					'post_type'   => 'shop_order',
+					'post_status' => 'any',
+					'fields'      => 'ids',
+				)
+			);
+			if ( !empty( $orders ) ) {
+				list( $order_id ) = $orders;
+			}
+		}
+		if ( $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( $order ) {
+				return $order;
+			}
 		}
 	}
 

--- a/src/Mondu/Mondu/Support/Helper.php
+++ b/src/Mondu/Mondu/Support/Helper.php
@@ -106,6 +106,7 @@ class Helper {
 
 	/**
 	 * Get order from order number
+	 * Tries to get it using the meta key _order_number otherwise gets it according to the plugin
 	 *
 	 * @param WC_Order $order
 	 * @return string


### PR DESCRIPTION
## Description

Support more plugins modifying order numbers. Tries to get it using the meta key `_order_number`; otherwise, gets it according to the plugin.

Fixes [PT-421](https://mondu.atlassian.net/browse/PT-421)

## Release information

Release:
Tickets: PT-421

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [ ] I have added tests that prove my fix is effective or that my feature works


[PT-421]: https://mondu.atlassian.net/browse/PT-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ