### PR TITLE
Remove cancel API call when the buyer bounces

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -60,6 +60,7 @@ Check out [Frequently Asked Questions](https://www.mondu.ai/faq) in the Mondu we
 = 2.1.4 =
 
 * Fix deprecated setting $instructions on payments
+* Remove cancel API call when the buyer bounces
 
 = 2.1.3 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.1.4 =
 
 * Fix deprecated setting $instructions on payments
+* Remove cancel API call when the buyer bounces
 
 = 2.1.3 =
 

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -23,7 +23,7 @@ class OrderData {
 			$cancel_url = $order->get_checkout_payment_url();
 		} else {
 			$decline_url = wc_get_checkout_url();
-			$cancel_url = $order->get_cancel_order_url_raw( wc_get_checkout_url() );
+			$cancel_url = wc_get_checkout_url();
 		}
 
 		$success_url = get_home_url() . '/?rest_route=/mondu/v1/orders/confirm&external_reference_id=' . $order->get_order_number() . '&return_url=' . urlencode( $success_url );


### PR DESCRIPTION
## Description

Remove cancel API call when the buyer bounces because our hosted checkout already does it.

Fixes [PT-969](https://mondu.atlassian.net/browse/PT-969)

## Release information

Release:
Tickets: PT-969

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [X] I have added tests that prove my fix is effective or that my feature works


[PT-969]: https://mondu.atlassian.net/browse/PT-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ