### PR TITLE
Change order state to failed when receiving the order declined webhook

### DIFF
--- a/src/Mondu/Mondu/Controllers/WebhooksController.php
+++ b/src/Mondu/Mondu/Controllers/WebhooksController.php
@@ -164,6 +164,12 @@ class WebhooksController extends WP_REST_Controller {
 			return $this->return_not_found();
 		}
 
+		$order->add_order_note( esc_html( sprintf( __( 'Mondu order is on declined state.', 'mondu' ) ) ), false );
+
+		if ( $order->get_status() == 'on-hold' ) {
+			$order->update_status('wc-failed', __('Failed', 'woocommerce'));
+		}
+
 		return $this->return_success();
 	}
 


### PR DESCRIPTION
## Description

Change order state to failed when receiving the order declined webhook.

Fixes [PT-969](https://mondu.atlassian.net/browse/PT-969)

## Release information

Release: p
Tickets: PT-969

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings



[PT-969]: https://mondu.atlassian.net/browse/PT-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ