### PR TITLE
[PT-1027] Improve OrdersController confirm endpoint.

### DIFF
--- a/src/Mondu/Mondu/Controllers/OrdersController.php
+++ b/src/Mondu/Mondu/Controllers/OrdersController.php
@@ -43,9 +43,13 @@ class OrdersController extends WP_REST_Controller {
 		$order_number   = $params['external_reference_id'];
 		$mondu_order_id = $params['order_uuid'];
 		$return_url     = urldecode( $params['return_url'] );
-		$order          = Helper::get_order_from_order_number( $order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $order_number, $mondu_order_id );
 
 		try {
+			if (!$order) {
+				throw new \Exception(__('Order not found'));
+			}
+
 			if ( isset( WC()->cart ) ) {
 				WC()->cart->empty_cart();
 			}

--- a/src/Mondu/Mondu/Controllers/WebhooksController.php
+++ b/src/Mondu/Mondu/Controllers/WebhooksController.php
@@ -97,7 +97,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -116,7 +116,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -135,7 +135,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -158,7 +158,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -180,7 +180,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -198,7 +198,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -216,7 +216,7 @@ class WebhooksController extends WP_REST_Controller {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
 
 		if ( !$order ) {
 			return $this->return_not_found();

--- a/src/Mondu/Mondu/Controllers/WebhooksController.php
+++ b/src/Mondu/Mondu/Controllers/WebhooksController.php
@@ -175,12 +175,13 @@ class WebhooksController extends WP_REST_Controller {
 
 	private function handle_invoice_created( $params ) {
 		$woocommerce_order_number = $params['external_reference_id'];
+		$mondu_order_id           = $params['order_uuid'];
 
 		if ( !$woocommerce_order_number ) {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -193,12 +194,13 @@ class WebhooksController extends WP_REST_Controller {
 
 	private function handle_invoice_payment( $params ) {
 		$woocommerce_order_number = $params['external_reference_id'];
+		$mondu_order_id           = $params['order_uuid'];
 
 		if ( !$woocommerce_order_number ) {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();
@@ -211,12 +213,13 @@ class WebhooksController extends WP_REST_Controller {
 
 	private function handle_invoice_canceled( $params ) {
 		$woocommerce_order_number = $params['external_reference_id'];
+		$mondu_order_id           = $params['order_uuid'];
 
 		if ( !$woocommerce_order_number ) {
 			throw new MonduException(__('Required params missing.', 'mondu'));
 		}
 
-		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number );
+		$order = Helper::get_order_from_order_number_or_uuid( $woocommerce_order_number, $mondu_order_id );
 
 		if ( !$order ) {
 			return $this->return_not_found();


### PR DESCRIPTION
## Description

This pr improves on trying to fetch the order from woocommerce by order number by trying to fetch it by mondu uuid as a fallback

[PT-1027](https://mondu.atlassian.net/browse/PT-1027)

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings


[PT-1027]: https://mondu.atlassian.net/browse/PT-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ