### PR TITLE
[incident-79] send null instead of 0 for buyer external_reference_id

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: mondu-ai, arthurmmoreira, tikohov20
 Tags: mondu, woocommerce, e-commerce, ecommerce, store, sales, sell, woo, woo commerce, shop, cart, shopping cart, sell online, checkout, payment, payments, bnpl, b2b
 Requires at least: 5.9.0
 Tested up to: 6.2.2
-Stable tag: 2.1.6
+Stable tag: 2.1.7
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -56,6 +56,10 @@ Check out [Frequently Asked Questions](https://www.mondu.ai/faq) in the Mondu we
 3. Grow now. Pay better.
 
 == Changelog ==
+
+= 2.1.7 =
+
+* Bugfixes and improvements
 
 = 2.1.6 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 2.1.7 =
+
+* Bugfixes and improvements
+
 = 2.1.6 =
 
 * Do not call the confirm endpoint if we are not changing the order state

--- a/mondu-buy-now-pay-later.php
+++ b/mondu-buy-now-pay-later.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mondu Buy Now Pay Later
  * Plugin URI: https://github.com/mondu-ai/bnpl-checkout-woocommerce/releases
  * Description: Mondu provides B2B E-commerce and B2B marketplaces with an online payment solution to buy now and pay later.
- * Version: 2.1.6
+ * Version: 2.1.7
  * Author: Mondu
  * Author URI: https://mondu.ai
  *
@@ -25,7 +25,7 @@ if ( !defined( 'ABSPATH' ) ) {
 	die( 'Direct access not allowed' );
 }
 
-define( 'MONDU_PLUGIN_VERSION', '2.1.6' );
+define( 'MONDU_PLUGIN_VERSION', '2.1.7' );
 define( 'MONDU_PLUGIN_FILE', __FILE__ );
 define( 'MONDU_PLUGIN_PATH', __DIR__ );
 define( 'MONDU_PLUGIN_BASENAME', plugin_basename(MONDU_PLUGIN_FILE) );

--- a/src/Mondu/Mondu/Support/OrderData.php
+++ b/src/Mondu/Mondu/Support/OrderData.php
@@ -124,7 +124,7 @@ class OrderData {
 		$billing_last_name  = $order->get_billing_last_name();
 		$billing_email      = $order->get_billing_email();
 		$billing_phone      = $order->get_billing_phone();
-		$customer_id        = $order->get_customer_id();
+		$customer_id        = $order->get_customer_id() ?: null;
 
 		$billing_address_line1 = $order->get_billing_address_1();
 		$billing_address_line2 = $order->get_billing_address_2();


### PR DESCRIPTION
## Description

Fix for a bug where 0 was sent as external_reference_id instead of null


## Release information

Release: p
Tickets: PT-1370

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
